### PR TITLE
Enable FindMatlab tests using MathWorks' GitHub Actions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,12 @@ jobs:
           cd ${GITHUB_WORKSPACE}/Dashboards/Scripts
           wget https://gitlab.kitware.com/cmake/dashboard-scripts/-/raw/master/cmake_common.cmake 
 
+      - name: Setup MATLAB
+        uses: matlab-actions/setup-matlab@v1
+
       - name: Run Nightly Test
         run: |
+          env
+          which matlab
           ctest --version
           ctest -S ${GITHUB_WORKSPACE}/Dashboards/Scripts/matlab_dashboard.cmake -V

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install cmake build-essential
+          sudo apt-get install cmake build-essential libssl-dev
           cd ${GITHUB_WORKSPACE}/Dashboards/Scripts
           wget https://gitlab.kitware.com/cmake/dashboard-scripts/-/raw/master/cmake_common.cmake 
 

--- a/Dashboards/Scripts/matlab_dashboard.cmake
+++ b/Dashboards/Scripts/matlab_dashboard.cmake
@@ -3,6 +3,7 @@ set(CTEST_SITE "ghamatlab.ami.iit.it")
 set(CTEST_BUILD_NAME "Linux-GCC-Matlab")
 set(CTEST_BUILD_CONFIGURATION Debug)
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+set(dashboard_cache "CMake_TEST_FindMatlab:BOOL=TRUE")
 # For now, do not submit 
 set(dashboard_no_submit TRUE)
 include(${CTEST_SCRIPT_DIRECTORY}/cmake_common.cmake)

--- a/Dashboards/Scripts/matlab_dashboard.cmake
+++ b/Dashboards/Scripts/matlab_dashboard.cmake
@@ -4,5 +4,5 @@ set(CTEST_BUILD_NAME "Linux-GCC-Matlab")
 set(CTEST_BUILD_CONFIGURATION Debug)
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 # For now, do not submit 
-set(dashboard_no_submit FALSE)
+set(dashboard_no_submit TRUE)
 include(${CTEST_SCRIPT_DIRECTORY}/cmake_common.cmake)


### PR DESCRIPTION
This PR adds to the nightly test the FindMatlab's tests, using the GitHub Actions documented in https://github.com/matlab-actions/overview .

After this modifications, only two tests are not passing:
~~~
2021-09-14T13:20:58.7449565Z The following tests FAILED:
2021-09-14T13:20:58.7450986Z 	166 - FindMatlab.basic_checks (Failed)
2021-09-14T13:20:58.7452012Z 	170 - FindMatlab.r2018a_check (Failed)
2021-09-14T13:20:58.8440217Z Post job cleanup.
~~~

However, before adding MATLAB, all 6 tests related to FindMatlab were failing:
~~~
2021-09-14T10:43:46.1738469Z The following tests FAILED:
2021-09-14T10:43:46.1739808Z 	166 - FindMatlab.basic_checks (Failed)
2021-09-14T10:43:46.1740899Z 	168 - FindMatlab.components_checks (Failed)
2021-09-14T10:43:46.1741991Z 	169 - FindMatlab.failure_reports (Failed)
2021-09-14T10:43:46.1743001Z 	170 - FindMatlab.r2018a_check (Failed)
2021-09-14T10:43:46.1744024Z 	171 - FindMatlab.targets_checks (Failed)
2021-09-14T10:43:46.1745046Z 	579 - RunCMake.FindMatlab (Failed)
~~~

The last two missing tests will be debugged in a separte issue.
