### PR TITLE
Add CTEST_NO_TEST_HOME=ON to dashboard_cache

### DIFF
--- a/Dashboards/Scripts/matlab_dashboard.cmake
+++ b/Dashboards/Scripts/matlab_dashboard.cmake
@@ -5,7 +5,8 @@ set(CTEST_BUILD_CONFIGURATION Debug)
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 # Only run Matlab-related tests
 set(CTEST_TEST_ARGS INCLUDE Matlab)
-set(dashboard_cache "CMake_TEST_FindMatlab:BOOL=TRUE")
+set(dashboard_cache "CMake_TEST_FindMatlab:BOOL=TRUE
+CTEST_NO_TEST_HOME:BOOL=ON")
 # For now, do not submit 
 set(dashboard_no_submit TRUE)
 include(${CTEST_SCRIPT_DIRECTORY}/cmake_common.cmake)


### PR DESCRIPTION
As discussed in https://github.com/traversaro/cmake-nightly-testing-runner/issues/3 and reported upstream in https://github.com/matlab-actions/setup-matlab/issues/31, changing the value of `HOME` env variable creates problem in MATLAB in finding its licenses. 

Given that polluting the home directory is not a problem in GitHub Actions, we can simply set `CTEST_NO_TEST_HOME` to `ON`  to avoid that the `HOME` env variable is redefined.