### PR TITLE
Test multiple MATLAB versions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build:
+    name: 'Linux-GCC-Matlab-${{ matrix.matlab_version }}' 
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        matlab_version: [R2020b, R2021a, R2021b, R2022a]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -29,9 +32,12 @@ jobs:
 
       - name: Setup MATLAB
         uses: matlab-actions/setup-matlab@v1
-
+        with:
+          release: ${{ matrix.matlab_version }}
+        
       - name: Run Nightly Test
         run: |
+          export GHA_MATLAB_VERSION=${{ matrix.matlab_version }}
           env
           which matlab
           ctest --version

--- a/Dashboards/Scripts/matlab_dashboard.cmake
+++ b/Dashboards/Scripts/matlab_dashboard.cmake
@@ -1,7 +1,6 @@
 # Client maintainer: silvio.traversaro@iit.it
 set(CTEST_SITE "ghamatlab.ami.iit.it")
 set(CTEST_BUILD_NAME "Linux-GCC-Matlab-$ENV{GHA_MATLAB_VERSION}")
-message(STATUS "===========> CTEST_BUILD_NAME: ${CTEST_BUILD_NAME}")
 set(CTEST_BUILD_CONFIGURATION Debug)
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 # Only run Matlab-related tests

--- a/Dashboards/Scripts/matlab_dashboard.cmake
+++ b/Dashboards/Scripts/matlab_dashboard.cmake
@@ -1,6 +1,7 @@
 # Client maintainer: silvio.traversaro@iit.it
 set(CTEST_SITE "ghamatlab.ami.iit.it")
-set(CTEST_BUILD_NAME "Linux-GCC-Matlab")
+set(CTEST_BUILD_NAME "Linux-GCC-Matlab-$ENV{GHA_MATLAB_VERSION}")
+message(STATUS "===========> CTEST_BUILD_NAME: ${CTEST_BUILD_NAME}")
 set(CTEST_BUILD_CONFIGURATION Debug)
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 # Only run Matlab-related tests


### PR DESCRIPTION
Test MATLAB versions that are supported in GitHub Actions and are supported on Ubuntu 20.04:
  * R2020b
  * R2021a
  * R2021b
  * R2022a